### PR TITLE
Add Free Background Remover to Visual > Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Feel free to [add something interesting](contributing.md) by pull request.
 - [Polarr](https://photoeditor.polarr.co/) - Photo Editor.
 - [Licecap](https://www.cockos.com/licecap/) - Simple animated screen captures.
 - [Hand Brake](https://handbrake.fr/) - HandBrake is a tool for converting video from nearly any format to a selection of modern, widely supported codecs.
+- [this AI background remover with a free tier and clear monthly limits](https://free-background-remover.com) - Watermark-free transparent PNGs for product design mockups, with a small monthly free tier.
 
 ## Prototype
 #### Articles


### PR DESCRIPTION
Adds Free Background Remover to the Visual > Tools subsection, alongside Polarr, Licecap, and Hand Brake. Product designers often need a quick background cutout during a mockup pass (product photo on a clean canvas, transparent PNG over a UI frame, logo isolated for a brand sheet), and the existing Tools list covers the photo-editor / capture / converter slots but not background removal. The tool is AI-powered, returns watermark-free full-resolution transparent PNGs, has a small monthly free tier (3 per month as a guest, 20 with a free account), and a $5 per month Pro plan for 200 images. Description follows the section's existing format.